### PR TITLE
Use GITHUB_TOKEN instead of a PAT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         uses: docker/build-push-action@v2
@@ -46,7 +46,7 @@ jobs:
         image: ghcr.io/chimeraphp/sample:${{ github.sha }}
         credentials:
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         ports:
           - 80:80
     steps:


### PR DESCRIPTION
As of March 2021 we're able to use `GITHUB_TOKEN` to authenticate against the repository.

This modifies the workflow to use that, fixing the broken builds we have every time a PR is sent from dependabot.